### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,12 +22,6 @@ Jupyter kernel in C# .NET Core which is the standard interface for SciSharp STAC
 * [Dash.NET](https://github.com/plotly/Dash.NET) A .NET interface to Dash- the most downloaded framework for building ML & data science web apps
 * [FsLab](https://fslab.org) An F# Community incubation space for data science
 
-### Alpha or Work-in-Progress
-
-* [Torch.NET](https://github.com/SciSharp/Torch.NET) C#/NETStandard bindings for PyTorch. Run your Tensor computations or Neural Networks on the GPU.
-* [SiaNet](https://github.com/SciSharp/SiaNet) A C# deep learning library, human friendly, CUDA/OpenCL supported, well structured, easy to extend.
-* [BotSharp](https://github.com/SciSharp/BotSharp) The Open Source AI Chatbot Platform Builder in 100% C# Running in .NET Core with Machine Learning algorithm.
-
 ### Referenced by:
 
 * https://medium.com/dev-genius/tensorflow-basic-setup-for-net-developers-d56bfb0af40e

--- a/README.md
+++ b/README.md
@@ -4,21 +4,32 @@ This repo contains the source code for http://scisharpstack.org
 ![scisharp](https://raw.githubusercontent.com/SciSharp/SciSharp-Portal/master/art/SciSharp256.png)
 
 ## Comprehensive list of all Projects
+
 ### Stable or Beta
+
 * [TensorFlow.NET](https://github.com/SciSharp/TensorFlow.NET) .NET Standard bindings for TensorFlow 
 * [NumSharp](https://github.com/SciSharp/NumSharp) Pure C# implementation of NumPy
-* [Keras.NET](https://github.com/SciSharp/Keras.NET) Keras.NET is a high-level neural networks API, written in C# with Python Binding and capable of running on top of TensorFlow, CNTK, or Theano. 
-* [Numpy.NET](https://github.com/SciSharp/Numpy.NET) C# bindings for NumPy - a fundamental library for scientific computing, machine learning and AI
+* [Keras.NET](https://github.com/SciSharp/Keras.NET) Keras.NET is a high-level neural networks API for C#/F# with Python Binding and capable of running on top of TensorFlow, CNTK, or Theano. 
+* [Numpy.NET](https://github.com/SciSharp/Numpy.NET) C#/F# bindings for NumPy - a fundamental library for scientific computing, machine learning and AI
 * [ICSharpCore](https://github.com/SciSharp/ICSharpCore)
 Jupyter kernel in C# .NET Core which is the standard interface for SciSharp STACK.
 * [SharpCV](https://github.com/SciSharp/SharpCV) A image library combines OpenCV and NumSharp together. SharpCV returns Mat object with NDArray supported.
 
+### Related technologies 
+
+* [.NET Interactive Notebooks](https://github.com/dotnet/interactive) Jupyter notebooks for C# and F#. Share code, explore data, write, and learn across your apps in ways you couldn't before.
+* [Plotly.NET](https://github.com/plotly/Plotly.NET) A .NET interface for plotly.js written in F#
+* [Dash.NET](https://github.com/plotly/Dash.NET) A .NET interface to Dash- the most downloaded framework for building ML & data science web apps
+* [FsLab](https://fslab.org) An F# Community incubation space for data science
+
 ### Alpha or Work-in-Progress
+
 * [Torch.NET](https://github.com/SciSharp/Torch.NET) C#/NETStandard bindings for PyTorch. Run your Tensor computations or Neural Networks on the GPU.
 * [SiaNet](https://github.com/SciSharp/SiaNet) A C# deep learning library, human friendly, CUDA/OpenCL supported, well structured, easy to extend.
 * [BotSharp](https://github.com/SciSharp/BotSharp) The Open Source AI Chatbot Platform Builder in 100% C# Running in .NET Core with Machine Learning algorithm.
 
 ### Referenced by:
+
 * https://medium.com/dev-genius/tensorflow-basic-setup-for-net-developers-d56bfb0af40e
 * https://www.youtube.com/watch?v=NpZP_TWhq04&t=155s
 * https://medium.com/machinelearningadvantage/run-tensorflow-machine-learning-code-in-c-with-almost-no-changes-77f7b629389


### PR DESCRIPTION

I propose SciSharp actively link out to .NET data science tech outside this repository (and likewise other tech should link into SciSharp)

This is just in the README - we can also think about doing this on the website

@Oceania2018 Do you have opinions about this?  We can't list everything but linking major assets likely to be used with SciSharp feels important